### PR TITLE
Listen on the ingress path

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -44,10 +44,14 @@ class NeutronServerPebbleHandler(sunbeam_chandlers.ServicePebbleHandler):
     def default_container_configs(self):
         return [
             sunbeam_core.ContainerConfigFile(
-                [self.container_name],
                 '/etc/neutron/neutron.conf',
                 'neutron',
-                'neutron')]
+                'neutron'),
+            sunbeam_core.ContainerConfigFile(
+                '/etc/neutron/api-paste.ini',
+                'neutron',
+                'neutron'),
+        ]
 
 
 class NeutronOperatorCharm(sunbeam_charm.OSBaseOperatorAPICharm):
@@ -167,7 +171,12 @@ class NeutronServerOVNPebbleHandler(NeutronServerPebbleHandler):
             sunbeam_core.ContainerConfigFile(
                 '/etc/neutron/plugins/ml2/ml2_conf.ini',
                 'root',
-                'root')]
+                'root'),
+            sunbeam_core.ContainerConfigFile(
+                '/etc/neutron/api-paste.ini',
+                'neutron',
+                'neutron'),
+        ]
 
 
 class NeutronOVNOperatorCharm(NeutronOperatorCharm):
@@ -211,6 +220,7 @@ class NeutronOVNOperatorCharm(NeutronOperatorCharm):
 class NeutronOVNXenaOperatorCharm(NeutronOVNOperatorCharm):
 
     openstack_release = 'xena'
+
 
 if __name__ == "__main__":
     # Note: use_juju_for_storage=True required per

--- a/src/templates/api-paste.ini.j2
+++ b/src/templates/api-paste.ini.j2
@@ -1,0 +1,62 @@
+[composite:neutron]                                                                                                                                                                                       [6/10808]
+use = egg:Paste#urlmap
+/: neutronversions_composite
+/healthcheck: healthcheck
+/v2.0: neutronapi_v2_0
+{% if ingress.ingress_path -%}
+{{ ingress.ingress_path }}: neutronversions_composite
+{{ ingress.ingress_path }}/v2.0: neutronapi_v2_0
+{% endif -%}
+
+[composite:neutronapi_v2_0]
+use = call:neutron.auth:pipeline_factory
+noauth = cors http_proxy_to_wsgi request_id fake_project_id catch_errors osprofiler extensions neutronapiapp_v2_0
+keystone = cors http_proxy_to_wsgi request_id catch_errors osprofiler authtoken keystonecontext extensions neutronapiapp_v2_0
+
+[composite:neutronversions_composite]
+use = call:neutron.auth:pipeline_factory
+noauth = cors http_proxy_to_wsgi neutronversions
+keystone = cors http_proxy_to_wsgi neutronversions
+
+[filter:request_id]
+paste.filter_factory = oslo_middleware:RequestId.factory
+
+[filter:catch_errors]
+paste.filter_factory = oslo_middleware:CatchErrors.factory
+
+[filter:cors]
+paste.filter_factory = oslo_middleware.cors:filter_factory
+oslo_config_project = neutron
+
+[filter:project_id]
+paste.filter_factory = neutron.api.extensions:ProjectIdMiddleware.factory
+oslo_config_project = neutron
+
+[filter:fake_project_id]
+paste.filter_factory = neutron.auth:NoauthFakeProjectId.factory
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware.http_proxy_to_wsgi:HTTPProxyToWSGI.factory
+
+[filter:keystonecontext]
+paste.filter_factory = neutron.auth:NeutronKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:extensions]
+paste.filter_factory = neutron.api.extensions:plugin_aware_extension_middleware_factory
+
+[app:neutronversions]
+paste.app_factory = neutron.pecan_wsgi.app:versions_factory
+
+[app:neutronapiapp_v2_0]
+paste.app_factory = neutron.api.v2.router:APIRouter.factory
+
+[filter:osprofiler]
+paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
+
+[app:healthcheck]
+paste.app_factory = oslo_middleware:Healthcheck.app_factory
+backends = disable_by_file
+disable_by_file_path = /var/lib/neutron/healthcheck_disable

--- a/unit_tests/test_neutron_charm.py
+++ b/unit_tests/test_neutron_charm.py
@@ -78,6 +78,7 @@ class TestNeutronOperatorCharm(test_utils.CharmTestCase):
 
         config_files = [
             '/etc/neutron/neutron.conf',
+            '/etc/neutron/api-paste.ini',
             '/etc/neutron/plugins/ml2/cert_host',
             '/etc/neutron/plugins/ml2/key_host',
             '/etc/neutron/plugins/ml2/ml2_conf.ini',


### PR DESCRIPTION
Traefik charm itself directs path based routing from
my.host/<model>-<app> to my.backend/<model>-<app> but neutron
is not configured to have to handle these paths. Add a mapping in
api-paste.ini for ingress paths.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>